### PR TITLE
feat: Add option to hide server IP address from the dashboard

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,8 @@ $config = array(
     'server_name'           => 'your_server_name',
     'server_ip'             => 'your_server_ip_here',
     'server_port'           => '25565',
+    # Hide server IP (true/false)
+    'hide_server_ip'        => false,
     # About your database
     'db_ip'                 => 'ip_of_your_database_here',
     'db_port'               => 'port_of_your_database_here',

--- a/resources/js/shared.js
+++ b/resources/js/shared.js
@@ -412,6 +412,15 @@ function setServerStats(infos) {
         displayElement(e, hostname)
     })
     copyToClipboard.value = hostname
+
+    // Hide the server IP container if the hostname is hidden
+    copyToClipboardAction.forEach(e => {
+        if (hostname === "Hidden") {
+            e.classList.add('hidden')
+        } else {
+            e.classList.remove('hidden')
+        }
+    })
 }
 
 function isImageEmpty(imageDataURL) {

--- a/resources/php/scripts/get_server_stats.php
+++ b/resources/php/scripts/get_server_stats.php
@@ -30,10 +30,14 @@ $error = $error || ($status == null);
 // Construct our output
 $result = array();
 
-if ($config['server_port'] != "25565") {
-    $result['hostname'] = $config['server_ip'] . ':' . $config['server_port'];
+if (isset($config['hide_server_ip']) && $config['hide_server_ip']) {
+    $result['hostname'] = "Hidden";
 } else {
-    $result['hostname'] = $config['server_ip'];
+    if ($config['server_port'] != "25565") {
+        $result['hostname'] = $config['server_ip'] . ':' . $config['server_port'];
+    } else {
+        $result['hostname'] = $config['server_ip'];
+    }
 }
 
 $result['online_players'] = $error ? -1 : $status['players']['online'];


### PR DESCRIPTION
# Summary

This PR introduces a new configuration option that allows server administrators to hide the server's IP address from the public dashboard. This feature is designed to enhance server security and privacy by preventing direct IP exposure.

# Key Changes

- Configuration Update: Added a new toggle/parameter (e.g., hide_server_ip) in the configuration files (likely config/parameters.js or config.php).

- UI Modification: Updated the frontend components to check the visibility flag before rendering the server IP.

- Privacy Enhancement: When the option is enabled, the server IP is either masked, replaced with a placeholder (e.g., "Hidden"), or completely removed from the UI.

# Why this is needed

To prevent potential DDoS attacks or unwanted direct connections by giving owners control over whether their server's raw IP is visible to the public on the stats page.